### PR TITLE
:recycle: Resolve negative bounds after construction

### DIFF
--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -268,7 +268,6 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         self._fill()
 
         if slice.hasnegativebounds():
-            self._fill()
             slice = slice.withpositivebounds(self._cachesize)
 
         if slice.step < 0:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -228,7 +228,10 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         return len(self._cache)
 
     def _iterate(self, iterator: Iterator[_T_co]) -> Iterator[_T_co]:
-        slice = self._slice
+        slice = self.__slice
+        if slice.hasnegativebounds():
+            self._fill()
+            slice = slice.withpositivebounds(self._cachesize)
 
         if slice.step < 0:
             self._fill()

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -207,14 +207,6 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         self._cache = storage() if _cache is None else _cache
         self.__slice = _slice.fromslice(_indices)
 
-    @property
-    def _slice(self) -> _slice:
-        slice = self.__slice
-        if slice.hasnegativebounds():
-            self._fill()
-            slice = slice.withpositivebounds(self._cachesize)
-        return slice
-
     def _consume(self) -> Iterator[_T_co]:
         for item in self._iter:
             self._cache.append(item)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -205,7 +205,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         """Initialize."""
         self._iter = iter(iterable)
         self._cache = storage() if _cache is None else _cache
-        self.__slice = _slice.fromslice(_indices)
+        self._slice = _slice.fromslice(_indices)
 
     def _consume(self) -> Iterator[_T_co]:
         for item in self._iter:
@@ -220,7 +220,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         return len(self._cache)
 
     def _iterate(self, iterator: Iterator[_T_co]) -> Iterator[_T_co]:
-        slice = self.__slice
+        slice = self._slice
         if slice.hasnegativebounds():
             self._fill()
             slice = slice.withpositivebounds(self._cachesize)
@@ -255,7 +255,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
     def __len__(self) -> int:
         """Return the number of items in the sequence."""
-        slice = self.__slice
+        slice = self._slice
 
         self._fill()
 
@@ -274,7 +274,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         if index < 0:
             raise IndexError("lazysequence index out of range")
 
-        slice = self.__slice
+        slice = self._slice
         if slice.hasnegativebounds():  # pragma: no cover
             self._fill()
             slice = slice.withpositivebounds(self._cachesize)
@@ -342,7 +342,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
             return _slice(start, stop, step)
 
-        origin = self.__slice
+        origin = self._slice
         if origin.hasnegativebounds():  # pragma: no cover
             self._fill()
             origin = origin.withpositivebounds(self._cachesize)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -263,7 +263,10 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
     def __len__(self) -> int:
         """Return the number of items in the sequence."""
-        slice = self._slice
+        slice = self.__slice
+        if slice.hasnegativebounds():
+            self._fill()
+            slice = slice.withpositivebounds(self._cachesize)
 
         self._fill()
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -210,9 +210,13 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
         if slice.hasnegativebounds():
             self._fill()
-            self._slice = slice.withpositivebounds(self._cachesize)
+            self.__slice = slice.withpositivebounds(self._cachesize)
         else:
-            self._slice = slice
+            self.__slice = slice
+
+    @property
+    def _slice(self) -> _slice:
+        return self.__slice
 
     def _consume(self) -> Iterator[_T_co]:
         for item in self._iter:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -307,11 +307,11 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
     def _getslice(self, indices: slice) -> lazysequence[_T_co]:  # noqa: C901
         def resolve(index: int) -> Optional[int]:
-            if self._slice.step > 0:
-                return self._slice.resolve_noraise(index)
+            if origin.step > 0:
+                return origin.resolve_noraise(index)
 
             self._fill()
-            return self._slice.rresolve_noraise(index, self._cachesize)
+            return origin.rresolve_noraise(index, self._cachesize)
 
         def resolve_start(start: Optional[int], step: int) -> Optional[int]:
             assert start is None or start >= 0  # noqa: S101
@@ -328,15 +328,15 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
                 return resolve(stop)
 
             if step > 0:
-                return self._slice.stop
+                return origin.stop
 
-            if self._slice.start is None:
+            if origin.start is None:
                 return None
 
-            if self._slice.step < 0:
-                return self._slice.start + 1
+            if origin.step < 0:
+                return origin.start + 1
 
-            return self._slice.start - 1
+            return origin.start - 1
 
         def resolve_slice(aslice: _slice) -> _slice:
             if aslice.hasnegativebounds():
@@ -346,10 +346,11 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
             start = resolve_start(start, step)
             stop = resolve_stop(stop, step)
-            step *= self._slice.step
+            step *= origin.step
 
             return _slice(start, stop, step)
 
+        origin = self._slice
         theslice = resolve_slice(_slice.fromslice(indices))
 
         return lazysequence(self._iter, _cache=self._cache, _indices=theslice.asslice())

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -205,18 +205,15 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         """Initialize."""
         self._iter = iter(iterable)
         self._cache = storage() if _cache is None else _cache
-
-        slice = _slice.fromslice(_indices)
-
-        if slice.hasnegativebounds():
-            self._fill()
-            self.__slice = slice.withpositivebounds(self._cachesize)
-        else:
-            self.__slice = slice
+        self.__slice = _slice.fromslice(_indices)
 
     @property
     def _slice(self) -> _slice:
-        return self.__slice
+        slice = self.__slice
+        if slice.hasnegativebounds():
+            self._fill()
+            slice = slice.withpositivebounds(self._cachesize)
+        return slice
 
     def _consume(self) -> Iterator[_T_co]:
         for item in self._iter:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -350,7 +350,11 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
             return _slice(start, stop, step)
 
-        origin = self._slice
+        origin = self.__slice
+        if origin.hasnegativebounds():  # pragma: no cover
+            self._fill()
+            origin = origin.withpositivebounds(self._cachesize)
+
         theslice = resolve_slice(_slice.fromslice(indices))
 
         return lazysequence(self._iter, _cache=self._cache, _indices=theslice.asslice())

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -283,7 +283,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             raise IndexError("lazysequence index out of range")
 
         slice = self.__slice
-        if slice.hasnegativebounds():
+        if slice.hasnegativebounds():  # pragma: no cover
             self._fill()
             slice = slice.withpositivebounds(self._cachesize)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -282,7 +282,10 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         if index < 0:
             raise IndexError("lazysequence index out of range")
 
-        slice = self._slice
+        slice = self.__slice
+        if slice.hasnegativebounds():
+            self._fill()
+            slice = slice.withpositivebounds(self._cachesize)
 
         if slice.step >= 0:
             index = slice.resolve(index)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -264,11 +264,12 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
     def __len__(self) -> int:
         """Return the number of items in the sequence."""
         slice = self.__slice
+
+        self._fill()
+
         if slice.hasnegativebounds():
             self._fill()
             slice = slice.withpositivebounds(self._cachesize)
-
-        self._fill()
 
         if slice.step < 0:
             slice = slice.reverse(self._cachesize)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -282,11 +282,13 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         if index < 0:
             raise IndexError("lazysequence index out of range")
 
-        if self._slice.step >= 0:
-            index = self._slice.resolve(index)
+        slice = self._slice
+
+        if slice.step >= 0:
+            index = slice.resolve(index)
         else:
             self._fill()
-            index = self._slice.rresolve(index, self._cachesize)
+            index = slice.rresolve(index, self._cachesize)
 
         try:
             return self._cache[index]


### PR DESCRIPTION
- encapsulate property `_slice` with attribute `__slice`
- move resolution of negative bounds into function `_slice`
- inline function `_slice` into `_iterate`
- inline function `_slice` into `__len__`
- slide statement
- remove repeated call of idempotent function `_fill`
- extract variable `slice` in `_getitem`
- inline function `_slice` in `_getitem`
- exclude dead code from coverage
- extract variable `origin` in `_getslice`
- inline function `_slice` in `_getslice`
- remove function `_slice`
- rename attribute `__slice` to `_slice`
