### PR TITLE
:recycle: Convert `_slice` methods to accept a `Sized` instance instead of the size

### DIFF
--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -91,7 +91,9 @@ class _slice:  # noqa: N801
 
         return _slice(start, stop, step)
 
-    def length(self, size: int) -> int:
+    def length(self, sized: Sized) -> int:
+        size = len(sized)
+
         if self.stop is not None:
             size = min(size, self.stop)
 
@@ -265,7 +267,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         if slice.step < 0:
             slice = slice.reverse(self._cachesize)
 
-        return slice.length(self._cachesize)
+        return slice.length(self._total)
 
     def _getitem(self, index: int) -> _T_co:
         if index < 0:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -232,8 +232,9 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         slice = self._slice.positive(self._total)
 
         if slice.step < 0:
-            self._fill()
             slice = slice.reverse(self._total)
+
+            self._fill()
             return slice.apply(reversed(self._cache))
 
         return slice.apply(chain(self._cache, iterator))

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -107,9 +107,10 @@ class _slice:  # noqa: N801
 
         return size
 
-    def reverse(self, size: int) -> _slice:
+    def reverse(self, sized: Sized) -> _slice:
         assert self.step < 0  # noqa: S101
 
+        size = len(sized)
         start, stop, step = self.astuple()
         step = -step
 
@@ -232,7 +233,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
         if slice.step < 0:
             self._fill()
-            slice = slice.reverse(self._cachesize)
+            slice = slice.reverse(self._total)
             return slice.apply(reversed(self._cache))
 
         return slice.apply(chain(self._cache, iterator))
@@ -265,7 +266,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         self._fill()
 
         if slice.step < 0:
-            slice = slice.reverse(self._cachesize)
+            slice = slice.reverse(self._total)
 
         return slice.length(self._total)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -263,8 +263,6 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         """Return the number of items in the sequence."""
         slice = self._slice.positive(self._total)
 
-        self._fill()
-
         if slice.step < 0:
             slice = slice.reverse(self._total)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -174,10 +174,10 @@ class _slice:  # noqa: N801
 
         return index
 
-    def rresolve_noraise(self, index: int, size: int) -> int:
+    def rresolve_noraise(self, index: int, sized: Sized) -> int:
         """Resolve index backwards, defaulting to the first valid slot."""
         try:
-            return self.rresolve(index, size)
+            return self.rresolve(index, len(sized))
         except IndexError:
             return self.stop + 1 if self.stop is not None else 0
 
@@ -301,8 +301,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             if origin.step > 0:
                 return origin.resolve_noraise(index)
 
-            self._fill()
-            return origin.rresolve_noraise(index, self._cachesize)
+            return origin.rresolve_noraise(index, self._total)
 
         def resolve_start(start: Optional[int], step: int) -> Optional[int]:
             assert start is None or start >= 0  # noqa: S101

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -210,7 +210,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         class _Total(Sized):
             def __len__(self) -> int:
                 parent._fill()
-                return parent._cachesize
+                return len(parent._cache)
 
         self._iter = iter(iterable)
         self._cache = storage() if _cache is None else _cache
@@ -224,10 +224,6 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
     def _fill(self) -> None:
         self._cache.extend(self._iter)
-
-    @property
-    def _cachesize(self) -> int:
-        return len(self._cache)
 
     def _iterate(self, iterator: Iterator[_T_co]) -> Iterator[_T_co]:
         slice = self._slice.positive(self._total)
@@ -289,7 +285,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         except IndexError:
             pass
 
-        index -= self._cachesize
+        index -= len(self._cache)
 
         try:
             return next(islice(self._consume(), index, None))

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -158,10 +158,11 @@ class _slice:  # noqa: N801
         except IndexError:
             return self.stop - 1 if self.stop is not None else None
 
-    def rresolve(self, index: int, size: int) -> int:
+    def rresolve(self, index: int, sized: Sized) -> int:
         """Resolve index on a backward slice, where start >= stop and step < 0."""
         assert self.step < 0  # noqa: S101
 
+        size = len(sized)
         start, stop, step = self.astuple()
 
         assert start is not None  # noqa: S101
@@ -177,7 +178,7 @@ class _slice:  # noqa: N801
     def rresolve_noraise(self, index: int, sized: Sized) -> int:
         """Resolve index backwards, defaulting to the first valid slot."""
         try:
-            return self.rresolve(index, len(sized))
+            return self.rresolve(index, sized)
         except IndexError:
             return self.stop + 1 if self.stop is not None else 0
 
@@ -281,8 +282,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         if slice.step >= 0:
             index = slice.resolve(index)
         else:
-            self._fill()
-            index = slice.rresolve(index, self._cachesize)
+            index = slice.rresolve(index, self._total)
 
         try:
             return self._cache[index]


### PR DESCRIPTION
- _slice.length: change function declaration to take `Sized`
- _slice.reverse: change function declaration to take `Sized`
- __len__: remove redundant call of `_fill`
- _iterate: slide statement
- _slice.rresolve_noraise: change function declaration to take `Sized`
- _slice.rresolve: change function declaration to take `Sized`
- inline function `_cachesize`
