### PR TITLE
:recycle: Generalize method `_slice.resolve` to resolve an index on a slice

### DIFF
--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -153,7 +153,9 @@ class _slice:  # noqa: N801
 
         return index
 
-    def rresolve(self, index: int, sized: Sized, *, strict: bool = True) -> int:
+    def _resolve_backward(
+        self, index: int, sized: Sized, *, strict: bool = True
+    ) -> int:
         """Resolve index on a backward slice, where start >= stop and step < 0."""
         assert self.step < 0  # noqa: S101
 
@@ -272,7 +274,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         if slice.step >= 0:
             index = slice._resolve_forward(index)
         else:
-            index = slice.rresolve(index, self._total)
+            index = slice._resolve_backward(index, self._total)
 
         try:
             return self._cache[index]
@@ -291,7 +293,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             if origin.step > 0:
                 return origin._resolve_forward(index, strict=False)
 
-            return origin.rresolve(index, self._total, strict=False)
+            return origin._resolve_backward(index, self._total, strict=False)
 
         def resolve_start(start: Optional[int], step: int) -> Optional[int]:
             assert start is None or start >= 0  # noqa: S101

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -133,7 +133,7 @@ class _slice:  # noqa: N801
 
         return _slice(start, stop, step)
 
-    def resolve(self, index: int) -> int:
+    def resolve(self, index: int, *, strict: bool = True) -> int:
         """Resolve index on a forward slice, where start <= stop and step > 0."""
         assert self.step > 0  # noqa: S101
 
@@ -145,18 +145,17 @@ class _slice:  # noqa: N801
         index = start + index * step
 
         if stop is not None and index >= stop:
-            raise IndexError("lazysequence index out of range")
+            if strict:
+                raise IndexError("lazysequence index out of range")
+
+            # Defaulting to the last valid slot.
+            return stop - 1 if stop is not None else None
 
         return index
 
     def resolve_noraise(self, index: int) -> Optional[int]:
         """Resolve index, defaulting to the last valid slot."""
-        assert self.step > 0  # noqa: S101
-
-        try:
-            return self.resolve(index)
-        except IndexError:
-            return self.stop - 1 if self.stop is not None else None
+        return self.resolve(index, strict=False)
 
     def rresolve(self, index: int, sized: Sized) -> int:
         """Resolve index on a backward slice, where start >= stop and step < 0."""

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -292,10 +292,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
     def _getslice(self, indices: slice) -> lazysequence[_T_co]:  # noqa: C901
         def resolve(index: int) -> Optional[int]:
-            if origin.step > 0:
-                return origin._resolve_forward(index, strict=False)
-
-            return origin._resolve_backward(index, self._total, strict=False)
+            return origin.resolve(index, self._total, strict=False)
 
         def resolve_start(start: Optional[int], step: int) -> Optional[int]:
             assert start is None or start >= 0  # noqa: S101

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -133,6 +133,11 @@ class _slice:  # noqa: N801
 
         return _slice(start, stop, step)
 
+    def resolve(self: _slice, index: int, sized: Sized) -> int:
+        if self.step >= 0:
+            return self._resolve_forward(index)
+        return self._resolve_backward(index, sized)
+
     def _resolve_forward(self, index: int, *, strict: bool = True) -> int:
         """Resolve index on a forward slice, where start <= stop and step > 0."""
         assert self.step > 0  # noqa: S101
@@ -271,10 +276,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
         slice = self._slice.positive(self._total)
 
-        if slice.step >= 0:
-            index = slice._resolve_forward(index)
-        else:
-            index = slice._resolve_backward(index, self._total)
+        index = slice.resolve(index, self._total)
 
         try:
             return self._cache[index]

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -174,10 +174,6 @@ class _slice:  # noqa: N801
 
         return index
 
-    def rresolve_noraise(self, index: int, sized: Sized) -> int:
-        """Resolve index backwards, defaulting to the first valid slot."""
-        return self.rresolve(index, sized, strict=False)
-
 
 _defaultslice = slice(None)
 
@@ -295,7 +291,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             if origin.step > 0:
                 return origin.resolve(index, strict=False)
 
-            return origin.rresolve_noraise(index, self._total)
+            return origin.rresolve(index, self._total, strict=False)
 
         def resolve_start(start: Optional[int], step: int) -> Optional[int]:
             assert start is None or start >= 0  # noqa: S101

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -134,9 +134,11 @@ class _slice:  # noqa: N801
         return _slice(start, stop, step)
 
     def resolve(self: _slice, index: int, sized: Sized, *, strict: bool = True) -> int:
-        if self.step >= 0:
-            return self._resolve_forward(index, strict=strict)
-        return self._resolve_backward(index, sized, strict=strict)
+        return (
+            self._resolve_forward(index, strict=strict)
+            if self.step >= 0
+            else self._resolve_backward(index, sized, strict=strict)
+        )
 
     def _resolve_forward(self, index: int, *, strict: bool = True) -> int:
         """Resolve index on a forward slice, where start <= stop and step > 0."""

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -133,7 +133,7 @@ class _slice:  # noqa: N801
 
         return _slice(start, stop, step)
 
-    def resolve(self, index: int, *, strict: bool = True) -> int:
+    def _resolve_forward(self, index: int, *, strict: bool = True) -> int:
         """Resolve index on a forward slice, where start <= stop and step > 0."""
         assert self.step > 0  # noqa: S101
 
@@ -270,7 +270,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         slice = self._slice.positive(self._total)
 
         if slice.step >= 0:
-            index = slice.resolve(index)
+            index = slice._resolve_forward(index)
         else:
             index = slice.rresolve(index, self._total)
 
@@ -289,7 +289,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
     def _getslice(self, indices: slice) -> lazysequence[_T_co]:  # noqa: C901
         def resolve(index: int) -> Optional[int]:
             if origin.step > 0:
-                return origin.resolve(index, strict=False)
+                return origin._resolve_forward(index, strict=False)
 
             return origin.rresolve(index, self._total, strict=False)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -153,10 +153,6 @@ class _slice:  # noqa: N801
 
         return index
 
-    def resolve_noraise(self, index: int) -> Optional[int]:
-        """Resolve index, defaulting to the last valid slot."""
-        return self.resolve(index, strict=False)
-
     def rresolve(self, index: int, sized: Sized) -> int:
         """Resolve index on a backward slice, where start >= stop and step < 0."""
         assert self.step < 0  # noqa: S101
@@ -296,7 +292,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
     def _getslice(self, indices: slice) -> lazysequence[_T_co]:  # noqa: C901
         def resolve(index: int) -> Optional[int]:
             if origin.step > 0:
-                return origin.resolve_noraise(index)
+                return origin.resolve(index, strict=False)
 
             return origin.rresolve_noraise(index, self._total)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -133,10 +133,10 @@ class _slice:  # noqa: N801
 
         return _slice(start, stop, step)
 
-    def resolve(self: _slice, index: int, sized: Sized) -> int:
+    def resolve(self: _slice, index: int, sized: Sized, *, strict: bool = True) -> int:
         if self.step >= 0:
-            return self._resolve_forward(index)
-        return self._resolve_backward(index, sized)
+            return self._resolve_forward(index, strict=strict)
+        return self._resolve_backward(index, sized, strict=strict)
 
     def _resolve_forward(self, index: int, *, strict: bool = True) -> int:
         """Resolve index on a forward slice, where start <= stop and step > 0."""

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -153,7 +153,7 @@ class _slice:  # noqa: N801
 
         return index
 
-    def rresolve(self, index: int, sized: Sized) -> int:
+    def rresolve(self, index: int, sized: Sized, *, strict: bool = True) -> int:
         """Resolve index on a backward slice, where start >= stop and step < 0."""
         assert self.step < 0  # noqa: S101
 
@@ -166,16 +166,17 @@ class _slice:  # noqa: N801
         index = start + index * step
 
         if index < 0 or stop is not None and index <= stop:
-            raise IndexError("lazysequence index out of range")
+            if strict:
+                raise IndexError("lazysequence index out of range")
+
+            # Defaulting to the first valid slot.
+            return stop + 1 if stop is not None else 0
 
         return index
 
     def rresolve_noraise(self, index: int, sized: Sized) -> int:
         """Resolve index backwards, defaulting to the first valid slot."""
-        try:
-            return self.rresolve(index, sized)
-        except IndexError:
-            return self.stop + 1 if self.stop is not None else 0
+        return self.rresolve(index, sized, strict=False)
 
 
 _defaultslice = slice(None)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -149,7 +149,7 @@ class _slice:  # noqa: N801
                 raise IndexError("lazysequence index out of range")
 
             # Defaulting to the last valid slot.
-            return stop - 1 if stop is not None else None
+            return stop - 1
 
         return index
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -136,7 +136,7 @@ class _slice:  # noqa: N801
     def resolve(self: _slice, index: int, sized: Sized, *, strict: bool = True) -> int:
         return (
             self._resolve_forward(index, strict=strict)
-            if self.step >= 0
+            if self.step > 0
             else self._resolve_backward(index, sized, strict=strict)
         )
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -291,22 +291,19 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             raise IndexError("lazysequence index out of range") from None
 
     def _getslice(self, indices: slice) -> lazysequence[_T_co]:  # noqa: C901
-        def resolve(index: int) -> Optional[int]:
-            return origin.resolve(index, self._total, strict=False)
-
         def resolve_start(start: Optional[int], step: int) -> Optional[int]:
             assert start is None or start >= 0  # noqa: S101
 
             if start is None:
                 start = 0 if step > 0 else len(self) - 1
 
-            return resolve(start)
+            return origin.resolve(start, self._total, strict=False)
 
         def resolve_stop(stop: Optional[int], step: int) -> Optional[int]:
             assert stop is None or stop >= 0  # noqa: S101
 
             if stop is not None:
-                return resolve(stop)
+                return origin.resolve(stop, self._total, strict=False)
 
             if step > 0:
                 return origin.stop


### PR DESCRIPTION
- _slice.resolve: parameterize function using `strict` flag
- _slice.resolve_noraise: inline function
- _slice.rresolve: parameterize function using `strict` flag
- _slice.rresolve_noraise: inline function
- _slice._resolve_forward: rename function from `resolve`
- _slice._resolve_backward: rename function from `rresolve`
- _slice._resolve_forward: remove dead code
- _slice.resolve: extract function from `_getitem`
- _slice.resolve: parameterize function using `strict` flag
- _getslice: resolve: replace inline code with function call to `_slice.resolve`
- _getslice: resolve: inline function
- _slice.resolve: replace `if` statement with ternary
- _slice.resolve: do not compare step with zero explicitly
