### PR TITLE
:recycle: Only call `_slice.positive` from other `_slice` methods

### DIFF
--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -98,6 +98,8 @@ class _slice:  # noqa: N801
         return _slice(start, stop, step)
 
     def length(self, sized: Sized) -> int:
+        self = self.positive(sized)
+
         size = len(sized)
 
         if self.stop is not None:
@@ -266,8 +268,6 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
         if slice.step < 0:
             slice = slice.reverse(self._total)
-
-        slice = slice.positive(self._total)
 
         return slice.length(self._total)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -229,13 +229,13 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
     def _iterate(self, iterator: Iterator[_T_co]) -> Iterator[_T_co]:
         slice = self._slice
 
-        if slice.step < 0:
+        if slice.step > 0:
+            iterable: Iterable[_T_co] = chain(self._cache, iterator)
+        else:
             slice = slice.reverse(self._total)
 
             self._fill()
-            iterable: Iterable[_T_co] = reversed(self._cache)
-        else:
-            iterable = chain(self._cache, iterator)
+            iterable = reversed(self._cache)
 
         return slice.apply(iterable, self._total)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -326,9 +326,9 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             return origin.start - 1
 
         def resolve_slice(origin: _slice, aslice: _slice) -> _slice:
-            origin = origin.positive(self._total)
             start, stop, step = aslice.positive(self).astuple()
 
+            origin = origin.positive(self._total)
             start = resolve_start(origin, start, step)
             stop = resolve_stop(origin, stop, step)
             step *= origin.step

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -136,9 +136,6 @@ class _slice:  # noqa: N801
 
     def resolve2(self, index: int, sized: Sized, *, strict: bool = True) -> int:
         self = self.positive(sized)
-        return self.resolve(index, sized, strict=strict)
-
-    def resolve(self: _slice, index: int, sized: Sized, *, strict: bool = True) -> int:
         return (
             self._resolve_forward(index, strict=strict)
             if self.step > 0

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -266,8 +266,8 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
         if slice.step < 0:
             slice = slice.reverse(self._total)
-        else:
-            slice = slice.positive(self._total)
+
+        slice = slice.positive(self._total)
 
         return slice.length(self._total)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -227,13 +227,15 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         self._cache.extend(self._iter)
 
     def _iterate(self, iterator: Iterator[_T_co]) -> Iterator[_T_co]:
-        if self._slice.step < 0:
-            slice = self._slice.reverse(self._total)
+        slice = self._slice
+
+        if slice.step < 0:
+            slice = slice.reverse(self._total)
 
             self._fill()
             iterable: Iterable[_T_co] = reversed(self._cache)
         else:
-            slice = self._slice.positive(self._total)
+            slice = slice.positive(self._total)
             iterable = chain(self._cache, iterator)
 
         return slice.apply(iterable)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -117,8 +117,8 @@ class _slice:  # noqa: N801
     def reverse(self, sized: Sized) -> _slice:
         assert self.step < 0  # noqa: S101
 
-        size = len(sized)
         start, stop, step = self.positive(sized).astuple()
+        size = len(sized)
         step = -step
 
         assert start is not None  # noqa: S101

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -81,8 +81,8 @@ class _slice:  # noqa: N801
     def astuple(self) -> Tuple[Optional[int], Optional[int], int]:
         return self.start, self.stop, self.step
 
-    def apply(self, iterable: Iterable[_T_co]) -> Iterator[_T_co]:
-        return islice(iterable, *self.astuple())
+    def apply(self, iterable: Iterable[_T_co], sized: Sized) -> Iterator[_T_co]:
+        return islice(iterable, *self.positive(sized).astuple())
 
     def positive(self, sized: Sized) -> _slice:
         start, stop, step = self.astuple()
@@ -237,7 +237,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         else:
             iterable = chain(self._cache, iterator)
 
-        return slice.positive(self._total).apply(iterable)
+        return slice.apply(iterable, self._total)
 
     def __iter__(self) -> Iterator[_T_co]:
         """Iterate over the items in the sequence."""

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -114,6 +114,7 @@ class _slice:  # noqa: N801
         return size
 
     def reverse(self, sized: Sized) -> _slice:
+        self = self.positive(sized)
         assert self.step < 0  # noqa: S101
 
         size = len(sized)
@@ -228,8 +229,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
     def _iterate(self, iterator: Iterator[_T_co]) -> Iterator[_T_co]:
         if self._slice.step < 0:
-            slice = self._slice.positive(self._total)
-            slice = slice.reverse(self._total)
+            slice = self._slice.reverse(self._total)
 
             self._fill()
             iterable: Iterable[_T_co] = reversed(self._cache)
@@ -263,8 +263,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
     def __len__(self) -> int:
         """Return the number of items in the sequence."""
         if self._slice.step < 0:
-            slice = self._slice.positive(self._total)
-            slice = slice.reverse(self._total)
+            slice = self._slice.reverse(self._total)
         else:
             slice = self._slice.positive(self._total)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -235,10 +235,9 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             self._fill()
             iterable: Iterable[_T_co] = reversed(self._cache)
         else:
-            slice = slice.positive(self._total)
             iterable = chain(self._cache, iterator)
 
-        return slice.apply(iterable)
+        return slice.positive(self._total).apply(iterable)
 
     def __iter__(self) -> Iterator[_T_co]:
         """Iterate over the items in the sequence."""

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -134,7 +134,7 @@ class _slice:  # noqa: N801
 
         return _slice(start, stop, step)
 
-    def resolve2(self, index: int, sized: Sized, *, strict: bool = True) -> int:
+    def resolve(self, index: int, sized: Sized, *, strict: bool = True) -> int:
         self = self.positive(sized)
         return (
             self._resolve_forward(index, strict=strict)
@@ -278,7 +278,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         if index < 0:
             raise IndexError("lazysequence index out of range")
 
-        index = self._slice.resolve2(index, self._total)
+        index = self._slice.resolve(index, self._total)
 
         try:
             return self._cache[index]
@@ -301,7 +301,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             if start is None:
                 start = 0 if step > 0 else len(self) - 1
 
-            return origin.resolve2(start, self._total, strict=False)
+            return origin.resolve(start, self._total, strict=False)
 
         def resolve_stop(
             origin: _slice, stop: Optional[int], step: int
@@ -309,7 +309,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             assert stop is None or stop >= 0  # noqa: S101
 
             if stop is not None:
-                return origin.resolve2(stop, self._total, strict=False)
+                return origin.resolve(stop, self._total, strict=False)
 
             origin = origin.positive(self._total)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -262,10 +262,12 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
     def __len__(self) -> int:
         """Return the number of items in the sequence."""
-        if self._slice.step < 0:
-            slice = self._slice.reverse(self._total)
+        slice = self._slice
+
+        if slice.step < 0:
+            slice = slice.reverse(self._total)
         else:
-            slice = self._slice.positive(self._total)
+            slice = slice.positive(self._total)
 
         return slice.length(self._total)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -137,12 +137,12 @@ class _slice:  # noqa: N801
     def resolve(self, index: int, sized: Sized, *, strict: bool = True) -> int:
         self = self.positive(sized)
         return (
-            self._resolve_forward(index, strict=strict)
+            self._resolve_forward(index, sized, strict=strict)
             if self.step > 0
             else self._resolve_backward(index, sized, strict=strict)
         )
 
-    def _resolve_forward(self, index: int, *, strict: bool = True) -> int:
+    def _resolve_forward(self, index: int, sized: Sized, *, strict: bool = True) -> int:
         """Resolve index on a forward slice, where start <= stop and step > 0."""
         assert self.step > 0  # noqa: S101
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -296,7 +296,9 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             raise IndexError("lazysequence index out of range") from None
 
     def _getslice(self, indices: slice) -> lazysequence[_T_co]:  # noqa: C901
-        def resolve_start(start: Optional[int], step: int) -> Optional[int]:
+        def resolve_start(
+            origin: _slice, start: Optional[int], step: int
+        ) -> Optional[int]:
             assert start is None or start >= 0  # noqa: S101
 
             if start is None:
@@ -304,7 +306,9 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
             return origin.resolve(start, self._total, strict=False)
 
-        def resolve_stop(stop: Optional[int], step: int) -> Optional[int]:
+        def resolve_stop(
+            origin: _slice, stop: Optional[int], step: int
+        ) -> Optional[int]:
             assert stop is None or stop >= 0  # noqa: S101
 
             if stop is not None:
@@ -321,17 +325,17 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
             return origin.start - 1
 
-        def resolve_slice(aslice: _slice) -> _slice:
+        def resolve_slice(origin: _slice, aslice: _slice) -> _slice:
             start, stop, step = aslice.positive(self).astuple()
 
-            start = resolve_start(start, step)
-            stop = resolve_stop(stop, step)
+            start = resolve_start(origin, start, step)
+            stop = resolve_stop(origin, stop, step)
             step *= origin.step
 
             return _slice(start, stop, step)
 
         origin = self._slice.positive(self._total)
-        slice = resolve_slice(_slice.fromslice(indices))
+        slice = resolve_slice(origin, _slice.fromslice(indices))
 
         return lazysequence(self._iter, _cache=self._cache, _indices=slice.asslice())
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -98,20 +98,19 @@ class _slice:  # noqa: N801
         return _slice(start, stop, step)
 
     def length(self, sized: Sized) -> int:
-        self = self.positive(sized)
-
+        start, stop, step = self.positive(sized).astuple()
         size = len(sized)
 
-        if self.stop is not None:
-            size = min(size, self.stop)
+        if stop is not None:
+            size = min(size, stop)
 
-        if self.start is not None:
-            size = max(0, size - self.start)
+        if start is not None:
+            size = max(0, size - start)
 
         if size > 0:
             # This is equivalent to `math.ceil(result / step)`, but avoids
             # floating-point operations and importing `math`.
-            size = 1 + (size - 1) // self.step
+            size = 1 + (size - 1) // step
 
         return size
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -134,6 +134,10 @@ class _slice:  # noqa: N801
 
         return _slice(start, stop, step)
 
+    def resolve2(self, index: int, sized: Sized, *, strict: bool = True) -> int:
+        self = self.positive(sized)
+        return self.resolve(index, sized, strict=strict)
+
     def resolve(self: _slice, index: int, sized: Sized, *, strict: bool = True) -> int:
         return (
             self._resolve_forward(index, strict=strict)
@@ -277,9 +281,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         if index < 0:
             raise IndexError("lazysequence index out of range")
 
-        slice = self._slice.positive(self._total)
-
-        index = slice.resolve(index, self._total)
+        index = self._slice.resolve2(index, self._total)
 
         try:
             return self._cache[index]

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -301,11 +301,10 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         ) -> Optional[int]:
             assert start is None or start >= 0  # noqa: S101
 
-            origin = origin.positive(self._total)
-
             if start is None:
                 start = 0 if step > 0 else len(self) - 1
 
+            origin = origin.positive(self._total)
             return origin.resolve(start, self._total, strict=False)
 
         def resolve_stop(

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -301,6 +301,8 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         ) -> Optional[int]:
             assert start is None or start >= 0  # noqa: S101
 
+            origin = origin.positive(self._total)
+
             if start is None:
                 start = 0 if step > 0 else len(self) - 1
 
@@ -310,6 +312,8 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             origin: _slice, stop: Optional[int], step: int
         ) -> Optional[int]:
             assert stop is None or stop >= 0  # noqa: S101
+
+            origin = origin.positive(self._total)
 
             if stop is not None:
                 return origin.resolve(stop, self._total, strict=False)
@@ -328,7 +332,6 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         def resolve_slice(origin: _slice, aslice: _slice) -> _slice:
             start, stop, step = aslice.positive(self).astuple()
 
-            origin = origin.positive(self._total)
             start = resolve_start(origin, start, step)
             stop = resolve_stop(origin, stop, step)
             step *= origin.step

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -311,10 +311,11 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         ) -> Optional[int]:
             assert stop is None or stop >= 0  # noqa: S101
 
-            origin = origin.positive(self._total)
-
             if stop is not None:
+                origin = origin.positive(self._total)
                 return origin.resolve(stop, self._total, strict=False)
+
+            origin = origin.positive(self._total)
 
             if step > 0:
                 return origin.stop

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -230,14 +230,14 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         slice = self._slice
 
         if slice.step > 0:
-            iterable: Iterable[_T_co] = chain(self._cache, iterator)
+            iterator = chain(self._cache, iterator)
         else:
             slice = slice.reverse(self._total)
 
             self._fill()
-            iterable = reversed(self._cache)
+            iterator = reversed(self._cache)
 
-        return slice.apply(iterable, self._total)
+        return slice.apply(iterator, self._total)
 
     def __iter__(self) -> Iterator[_T_co]:
         """Iterate over the items in the sequence."""

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -135,7 +135,6 @@ class _slice:  # noqa: N801
         return _slice(start, stop, step)
 
     def resolve(self, index: int, sized: Sized, *, strict: bool = True) -> int:
-        self = self.positive(sized)
         return (
             self._resolve_forward(index, sized, strict=strict)
             if self.step > 0
@@ -144,6 +143,7 @@ class _slice:  # noqa: N801
 
     def _resolve_forward(self, index: int, sized: Sized, *, strict: bool = True) -> int:
         """Resolve index on a forward slice, where start <= stop and step > 0."""
+        self = self.positive(sized)
         assert self.step > 0  # noqa: S101
 
         start, stop, step = self.astuple()
@@ -166,6 +166,7 @@ class _slice:  # noqa: N801
         self, index: int, sized: Sized, *, strict: bool = True
     ) -> int:
         """Resolve index on a backward slice, where start >= stop and step < 0."""
+        self = self.positive(sized)
         assert self.step < 0  # noqa: S101
 
         size = len(sized)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -262,10 +262,11 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
     def __len__(self) -> int:
         """Return the number of items in the sequence."""
-        slice = self._slice.positive(self._total)
-
-        if slice.step < 0:
+        if self._slice.step < 0:
+            slice = self._slice.positive(self._total)
             slice = slice.reverse(self._total)
+        else:
+            slice = self._slice.positive(self._total)
 
         return slice.length(self._total)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -304,8 +304,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             if start is None:
                 start = 0 if step > 0 else len(self) - 1
 
-            origin = origin.positive(self._total)
-            return origin.resolve(start, self._total, strict=False)
+            return origin.resolve2(start, self._total, strict=False)
 
         def resolve_stop(
             origin: _slice, stop: Optional[int], step: int

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -165,11 +165,10 @@ class _slice:  # noqa: N801
         self, index: int, sized: Sized, *, strict: bool = True
     ) -> int:
         """Resolve index on a backward slice, where start >= stop and step < 0."""
-        self = self.positive(sized)
         assert self.step < 0  # noqa: S101
 
         size = len(sized)
-        start, stop, step = self.astuple()
+        start, stop, step = self.positive(sized).astuple()
 
         assert start is not None  # noqa: S101
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -143,10 +143,9 @@ class _slice:  # noqa: N801
 
     def _resolve_forward(self, index: int, sized: Sized, *, strict: bool = True) -> int:
         """Resolve index on a forward slice, where start <= stop and step > 0."""
-        self = self.positive(sized)
         assert self.step > 0  # noqa: S101
 
-        start, stop, step = self.astuple()
+        start, stop, step = self.positive(sized).astuple()
 
         if start is None:
             start = 0

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -326,6 +326,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             return origin.start - 1
 
         def resolve_slice(origin: _slice, aslice: _slice) -> _slice:
+            origin = origin.positive(self._total)
             start, stop, step = aslice.positive(self).astuple()
 
             start = resolve_start(origin, start, step)
@@ -334,8 +335,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
             return _slice(start, stop, step)
 
-        origin = self._slice.positive(self._total)
-        slice = resolve_slice(origin, _slice.fromslice(indices))
+        slice = resolve_slice(self._slice, _slice.fromslice(indices))
 
         return lazysequence(self._iter, _cache=self._cache, _indices=slice.asslice())
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -312,8 +312,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             assert stop is None or stop >= 0  # noqa: S101
 
             if stop is not None:
-                origin = origin.positive(self._total)
-                return origin.resolve(stop, self._total, strict=False)
+                return origin.resolve2(stop, self._total, strict=False)
 
             origin = origin.positive(self._total)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -227,14 +227,14 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         self._cache.extend(self._iter)
 
     def _iterate(self, iterator: Iterator[_T_co]) -> Iterator[_T_co]:
-        slice = self._slice.positive(self._total)
-
-        if slice.step < 0:
+        if self._slice.step < 0:
+            slice = self._slice.positive(self._total)
             slice = slice.reverse(self._total)
 
             self._fill()
             iterable: Iterable[_T_co] = reversed(self._cache)
         else:
+            slice = self._slice.positive(self._total)
             iterable = chain(self._cache, iterator)
 
         return slice.apply(iterable)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -114,11 +114,10 @@ class _slice:  # noqa: N801
         return size
 
     def reverse(self, sized: Sized) -> _slice:
-        self = self.positive(sized)
         assert self.step < 0  # noqa: S101
 
         size = len(sized)
-        start, stop, step = self.astuple()
+        start, stop, step = self.positive(sized).astuple()
         step = -step
 
         assert start is not None  # noqa: S101


### PR DESCRIPTION
- _iterate: slide statement
- __len__: slide statement
- _slice.reverse: move statement into function
- _slice.reverse: inline variable
- _iterate: extract variable `slice`
- _iterate: slide statement
- _slice.apply: move statement into function
- _iterate: reverse order of `if` branches
- _iterate: un-split `iterator` to cover `iterable`
- __len__: extract variable `slice`
- __len__: slide statement
- _slice.length: move statement into function
- _slice.length: extract variables start, stop, step
- _slice.reverse: slide statement
- _slice.resolve2: extract function from `_getitem`
- _getslice: add `origin` parameter to nested functions
- _getslice: move statement into function `resolve_slice`
- _getslice: slide statement
- _getslice: move statement into functions `resolve_start` and `resolve_stop`
- _getslice: resolve_start: slide statement
- _getslice: resolve_start: replace inline code with function call to `resolve2`
- _getslice: resolve_stop: slide statement
- _getslice: resolve_stop: replace inline code with function call
- _slice.resolve: inline function into `resolve2`
- _slice.resolve2: rename function to `resolve`
- _slice._resolve_forward: add parameter `sized`
- _slice.resolve: move statement into functions `_resolve_forward` and `_resolve_backward`
- _slice._resolve_forward: slide statement
- _slice._resolve_backward: slide statement
- _getslice: resolve_stop: move function into `_slice` class
