### PR TITLE
:recycle: Resolve slice `start` of None after construction

### DIFF
--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -169,7 +169,7 @@ class _slice:  # noqa: N801
                 raise IndexError("lazysequence index out of range")
 
             # Default to the last valid slot.
-            return stop - 1
+            return max(0, stop - 1)
 
         return index
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -182,7 +182,8 @@ class _slice:  # noqa: N801
         size = len(sized)
         start, stop, step = self.positive(sized).astuple()
 
-        assert start is not None  # noqa: S101
+        if start is None:
+            start = size - 1
 
         start = min(start, size - 1)
         index = start + index * step

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -168,7 +168,7 @@ class _slice:  # noqa: N801
             if strict:
                 raise IndexError("lazysequence index out of range")
 
-            # Defaulting to the last valid slot.
+            # Default to the last valid slot.
             return stop - 1
 
         return index
@@ -192,7 +192,7 @@ class _slice:  # noqa: N801
             if strict:
                 raise IndexError("lazysequence index out of range")
 
-            # Defaulting to the first valid slot.
+            # Default to the first valid slot.
             return stop + 1 if stop is not None else 0
 
         return index

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -131,7 +131,9 @@ class _slice:  # noqa: N801
         size = len(sized)
         step = -step
 
-        assert start is not None  # noqa: S101
+        if start is None:
+            start = size - 1
+
         start = (size - 1) - start
         start = max(0, start)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -334,12 +334,11 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             if step > 0:
                 return origin.positivestart(self._total)
 
-            if origin.stop is None:
-                return None
-
             stop = origin.positivestop(self._total)
 
-            assert stop is not None  # noqa: S101
+            if stop is None:
+                return None
+
             return stop + 1 if origin.step < 0 else stop - 1
 
         def resolve_slice(origin: _slice, aslice: _slice) -> _slice:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -328,10 +328,19 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         ) -> Optional[int]:
             assert start is None or start >= 0  # noqa: S101
 
-            if start is None:
-                start = 0 if step > 0 else len(self) - 1
+            if start is not None:
+                return origin.resolve(start, self._total, strict=False)
 
-            return origin.resolve(start, self._total, strict=False)
+            if step > 0:
+                return origin.positivestart(self._total)
+
+            if origin.stop is None:
+                return None
+
+            stop = origin.positivestop(self._total)
+
+            assert stop is not None  # noqa: S101
+            return stop + 1 if origin.step < 0 else stop - 1
 
         def resolve_slice(origin: _slice, aslice: _slice) -> _slice:
             start, stop, step = aslice.positive(self).astuple()

--- a/tests/test_lazysequence.py
+++ b/tests/test_lazysequence.py
@@ -304,6 +304,7 @@ SLICE_EXAMPLES_GETITEM_RAISES = [
 
 
 SLICE_EXAMPLES_GETSLICE = [
+    (10, None, None, None, slice(None, None, None)),
     (10, None, None, -100, slice(None, 2, None)),
     (10, None, None, -2, slice(None, 2, None)),
     (10, None, None, -2, slice(-2, None, None)),

--- a/tests/test_lazysequence.py
+++ b/tests/test_lazysequence.py
@@ -313,6 +313,8 @@ SLICE_EXAMPLES_GETSLICE = [
     (10, None, None, 2, slice(None, 2, None)),
     (10, None, None, 2, slice(-2, None, None)),
     (10, None, None, 100, slice(None, 2, None)),
+    (10, None, 9, None, slice(None, None, -1)),
+    (10, None, 9, None, slice(None, 2, -1)),
     (10, -5, -1, None, slice(None, 2, None)),
     (10, -5, -1, None, slice(-2, None, None)),
     (10, -5, 9, None, slice(None, 2, None)),

--- a/tests/test_lazysequence.py
+++ b/tests/test_lazysequence.py
@@ -305,6 +305,7 @@ SLICE_EXAMPLES_GETITEM_RAISES = [
 
 SLICE_EXAMPLES_GETSLICE = [
     (10, None, None, None, slice(None, None, None)),
+    (10, None, 0, None, slice(None, None, None)),
     (10, None, None, -100, slice(None, 2, None)),
     (10, None, None, -2, slice(None, 2, None)),
     (10, None, None, -2, slice(-2, None, None)),


### PR DESCRIPTION
- _slice.reverse: handle `start` being None
- _slice._resolve_backward: handle `start` being None
- _getslice: do not resolve `start=None` until after construction
- _slice.resolve: clean up comment
- _slice._resolve_forward: fix bogus negative return when stop is 0
- Add test for slice resolution with default arguments only
- Add test for slice resolution on slice with j=0
