### PR TITLE
:recycle: Resolve negative bounds during slice resolution, removing `_slice.positive*`

### DIFF
--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -245,9 +245,7 @@ class _slice:  # noqa: N801
         self, stop: Optional[int], step: int, sized: Sized
     ) -> Optional[int]:
         if stop is not None and stop < 0:
-            stop += self.length(sized)
-            if stop < 0:
-                stop = 0 if step > 0 else None
+            stop = _positivestop(stop, self.length(sized), step)
 
         if stop is not None:
             return self.resolve(stop, sized, strict=False)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -354,7 +354,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
         start: Optional[int]
         if slice.start is not None and slice.start < 0:
-            size = len(self)
+            size = self._slice.length(self._total)
             start = max(0, slice.start + size)
         else:
             start = slice.start

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -350,7 +350,8 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             raise IndexError("lazysequence index out of range") from None
 
     def _getslice(self, indices: slice) -> lazysequence[_T_co]:  # noqa: C901
-        slice = _slice.fromslice(indices).positive(self)
+        slice = _slice.fromslice(indices)
+        slice = slice.positive(self)
         slice = self._slice.resolve_slice(slice, self._total)
 
         return lazysequence(self._iter, _cache=self._cache, _indices=slice.asslice())

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -218,8 +218,6 @@ class _slice:  # noqa: N801
             size = self.length(sized)
             start = max(0, start + size)
 
-        assert start is None or start >= 0  # noqa: S101
-
         if start is not None:
             return self.resolve(start, sized, strict=False)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -106,17 +106,10 @@ class _slice:  # noqa: N801
         return _slice(start, stop, self.step)
 
     def _positivestart(self, sized: Sized) -> Optional[int]:
-        if self.start is not None and self.start < 0:
-            return _positivestart(self.start, len(sized))
         return self.start
 
     def _positivestop(self, sized: Sized) -> Optional[int]:
-        stop = self.stop
-
-        if stop is None or stop >= 0:
-            return stop
-
-        return _positivestop(stop, len(sized), self.step)
+        return self.stop
 
     def length(self, sized: Sized) -> int:
         origin = self

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -214,11 +214,11 @@ class _slice:  # noqa: N801
     def _resolve_start(
         self, start: Optional[int], step: int, sized: Sized
     ) -> Optional[int]:
-        if start is not None and start < 0:
-            size = self.length(sized)
-            start = max(0, start + size)
-
         if start is not None:
+            if start < 0:
+                size = self.length(sized)
+                start = max(0, start + size)
+
             return self.resolve(start, sized, strict=False)
 
         if step > 0:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -206,12 +206,6 @@ class _slice:  # noqa: N801
         start, stop, step = slice.astuple()
 
         start = self._resolve_start(start, step, sized)
-
-        if stop is not None and stop < 0:
-            stop += self.length(sized)
-            if stop < 0:
-                stop = 0 if step > 0 else None
-
         stop = self._resolve_stop(stop, step, sized)
         step *= self.step
 
@@ -242,6 +236,11 @@ class _slice:  # noqa: N801
     def _resolve_stop(
         self, stop: Optional[int], step: int, sized: Sized
     ) -> Optional[int]:
+        if stop is not None and stop < 0:
+            stop += self.length(sized)
+            if stop < 0:
+                stop = 0 if step > 0 else None
+
         assert stop is None or stop >= 0  # noqa: S101
 
         if stop is not None:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -358,7 +358,16 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         else:
             start = slice.start
 
-        stop = slice.positivestop(self)
+        stop = slice.stop
+
+        if stop is None or stop >= 0:
+            pass
+        else:
+            stop += len(self)
+            if stop >= 0:
+                pass
+            else:
+                stop = 0 if slice.step > 0 else None
 
         slice = _slice(start, stop, slice.step)
         slice = self._slice.resolve_slice(slice, self._total)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -232,12 +232,10 @@ class _slice:  # noqa: N801
         if step > 0:
             return self.stop
 
-        start = self.start
-
-        if start is None:
+        if self.start is None:
             return None
 
-        return start + 1 if self.step < 0 else start - 1
+        return self.start + 1 if self.step < 0 else self.start - 1
 
 
 _defaultslice = slice(None)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -224,11 +224,6 @@ class _slice:  # noqa: N801
             size = self.length(sized)
             start = max(0, start + size)
 
-        return self._resolve_start(start, step, sized)
-
-    def _resolve_start(
-        self, start: Optional[int], step: int, sized: Sized
-    ) -> Optional[int]:
         assert start is None or start >= 0  # noqa: S101
 
         if start is not None:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -86,7 +86,7 @@ class _slice:  # noqa: N801
 
     def positive(self, sized: Sized) -> _slice:
         start = self._positivestart(sized)
-        stop = self.positivestop(sized)
+        stop = self._positivestop(sized)
 
         return _slice(start, stop, self.step)
 
@@ -95,7 +95,7 @@ class _slice:  # noqa: N801
             return max(0, self.start + len(sized))
         return self.start
 
-    def positivestop(self, sized: Sized) -> Optional[int]:
+    def _positivestop(self, sized: Sized) -> Optional[int]:
         stop = self.stop
 
         if stop is None or stop >= 0:
@@ -224,7 +224,7 @@ class _slice:  # noqa: N801
         if step > 0:
             return self._positivestart(sized)
 
-        stop = self.positivestop(sized)
+        stop = self._positivestop(sized)
 
         if stop is None:
             return None
@@ -243,7 +243,7 @@ class _slice:  # noqa: N801
             return self.resolve(stop, sized, strict=False)
 
         if step > 0:
-            return self.positivestop(sized)
+            return self._positivestop(sized)
 
         start = self._positivestart(sized)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -202,7 +202,7 @@ class _slice:  # noqa: N801
 
         return index
 
-    def resolve_slice2(self, slice: _slice, sized: Sized) -> _slice:
+    def resolve_slice(self, slice: _slice, sized: Sized) -> _slice:
         start: Optional[int]
         if slice.start is not None and slice.start < 0:
             size = self.length(sized)
@@ -367,7 +367,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
     def _getslice(self, indices: slice) -> lazysequence[_T_co]:  # noqa: C901
         slice = _slice.fromslice(indices)
-        slice = self._slice.resolve_slice2(slice, self._total)
+        slice = self._slice.resolve_slice(slice, self._total)
 
         return lazysequence(self._iter, _cache=self._cache, _indices=slice.asslice())
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -97,10 +97,7 @@ class _slice:  # noqa: N801
         return self.start, self.stop, self.step
 
     def apply(self, iterable: Iterable[_T_co], sized: Sized) -> Iterator[_T_co]:
-        return islice(iterable, *self._positive(sized).astuple())
-
-    def _positive(self, sized: Sized) -> _slice:
-        return self
+        return islice(iterable, *self.astuple())
 
     def _positivestart(self, sized: Sized) -> Optional[int]:
         return self.start
@@ -114,7 +111,7 @@ class _slice:  # noqa: N801
         if origin.step < 0:
             origin = origin.reverse(sized)
 
-        start, stop, step = origin._positive(sized).astuple()
+        start, stop, step = origin.astuple()
         size = len(sized)
 
         if stop is not None:
@@ -133,7 +130,7 @@ class _slice:  # noqa: N801
     def reverse(self, sized: Sized) -> _slice:
         assert self.step < 0  # noqa: S101
 
-        start, stop, step = self._positive(sized).astuple()
+        start, stop, step = self.astuple()
         size = len(sized)
         step = -step
 
@@ -163,7 +160,7 @@ class _slice:  # noqa: N801
         """Resolve index on a forward slice, where start <= stop and step > 0."""
         assert self.step > 0  # noqa: S101
 
-        start, stop, step = self._positive(sized).astuple()
+        start, stop, step = self.astuple()
 
         if start is None:
             start = 0
@@ -186,7 +183,7 @@ class _slice:  # noqa: N801
         assert self.step < 0  # noqa: S101
 
         size = len(sized)
-        start, stop, step = self._positive(sized).astuple()
+        start, stop, step = self.astuple()
 
         if start is None:
             start = size - 1

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -205,7 +205,7 @@ class _slice:  # noqa: N801
     def resolve_slice(self, slice: _slice, sized: Sized) -> _slice:
         start, stop, step = slice.astuple()
 
-        start = self._resolve_start2(start, step, sized)
+        start = self._resolve_start(start, step, sized)
 
         if stop is not None and stop < 0:
             stop += self.length(sized)
@@ -217,7 +217,7 @@ class _slice:  # noqa: N801
 
         return _slice(start, stop, step)
 
-    def _resolve_start2(
+    def _resolve_start(
         self, start: Optional[int], step: int, sized: Sized
     ) -> Optional[int]:
         if start is not None and start < 0:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -100,10 +100,7 @@ class _slice:  # noqa: N801
         return islice(iterable, *self._positive(sized).astuple())
 
     def _positive(self, sized: Sized) -> _slice:
-        start = self._positivestart(sized)
-        stop = self._positivestop(sized)
-
-        return _slice(start, stop, self.step)
+        return self
 
     def _positivestart(self, sized: Sized) -> Optional[int]:
         return self.start

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -206,10 +206,10 @@ class _slice:  # noqa: N801
     def _resolve_start(
         self, start: Optional[int], step: int, sized: Sized
     ) -> Optional[int]:
-        if start is not None:
-            if start < 0:
-                start = _positivestart(start, self.length(sized))
+        if start is not None and start < 0:
+            start = _positivestart(start, self.length(sized))
 
+        if start is not None:
             return self.resolve(start, sized, strict=False)
 
         if step > 0:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -362,7 +362,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         stop = slice.stop
 
         if stop is not None and stop < 0:
-            stop += len(self)
+            stop += self._slice.length(self._total)
             if stop < 0:
                 stop = 0 if slice.step > 0 else None
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -205,11 +205,7 @@ class _slice:  # noqa: N801
     def resolve_slice(self, slice: _slice, sized: Sized) -> _slice:
         start, stop, step = slice.astuple()
 
-        if start is not None and start < 0:
-            size = self.length(sized)
-            start = max(0, start + size)
-
-        start = self._resolve_start(start, step, sized)
+        start = self._resolve_start2(start, step, sized)
 
         if stop is not None and stop < 0:
             stop += self.length(sized)
@@ -220,6 +216,15 @@ class _slice:  # noqa: N801
         step *= self.step
 
         return _slice(start, stop, step)
+
+    def _resolve_start2(
+        self, start: Optional[int], step: int, sized: Sized
+    ) -> Optional[int]:
+        if start is not None and start < 0:
+            size = self.length(sized)
+            start = max(0, start + size)
+
+        return self._resolve_start(start, step, sized)
 
     def _resolve_start(
         self, start: Optional[int], step: int, sized: Sized

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -221,8 +221,7 @@ class _slice:  # noqa: N801
     ) -> Optional[int]:
         if start is not None:
             if start < 0:
-                size = self.length(sized)
-                start = max(0, start + size)
+                start = _positivestart(start, self.length(sized))
 
             return self.resolve(start, sized, strict=False)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -85,12 +85,12 @@ class _slice:  # noqa: N801
         return islice(iterable, *self.positive(sized).astuple())
 
     def positive(self, sized: Sized) -> _slice:
-        start = self.positivestart(sized)
+        start = self._positivestart(sized)
         stop = self.positivestop(sized)
 
         return _slice(start, stop, self.step)
 
-    def positivestart(self, sized: Sized) -> Optional[int]:
+    def _positivestart(self, sized: Sized) -> Optional[int]:
         if self.start is not None and self.start < 0:
             return max(0, self.start + len(sized))
         return self.start
@@ -222,7 +222,7 @@ class _slice:  # noqa: N801
             return self.resolve(start, sized, strict=False)
 
         if step > 0:
-            return self.positivestart(sized)
+            return self._positivestart(sized)
 
         stop = self.positivestop(sized)
 
@@ -245,7 +245,7 @@ class _slice:  # noqa: N801
         if step > 0:
             return self.positivestop(sized)
 
-        start = self.positivestart(sized)
+        start = self._positivestart(sized)
 
         if start is None:
             return None

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -360,9 +360,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
         stop = slice.stop
 
-        if stop is None or stop >= 0:
-            pass
-        else:
+        if stop is not None and stop < 0:
             stop += len(self)
             if stop >= 0:
                 pass

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -52,6 +52,11 @@ from typing import Union
 _T_co = TypeVar("_T_co", covariant=True)
 
 
+def _positivestart(start: int, size: int) -> int:
+    assert start < 0  # noqa: S101
+    return max(0, start + size)
+
+
 @dataclass(frozen=True)
 class _slice:  # noqa: N801
     start: Optional[int]
@@ -92,7 +97,7 @@ class _slice:  # noqa: N801
 
     def _positivestart(self, sized: Sized) -> Optional[int]:
         if self.start is not None and self.start < 0:
-            return max(0, self.start + len(sized))
+            return _positivestart(self.start, len(sized))
         return self.start
 
     def _positivestop(self, sized: Sized) -> Optional[int]:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -57,6 +57,16 @@ def _positivestart(start: int, size: int) -> int:
     return max(0, start + size)
 
 
+def _positivestop(stop: int, size: int, step: int) -> Optional[int]:
+    assert stop < 0  # noqa: S101
+
+    stop += size
+    if stop >= 0:
+        return stop
+
+    return 0 if step > 0 else None
+
+
 @dataclass(frozen=True)
 class _slice:  # noqa: N801
     start: Optional[int]
@@ -106,11 +116,7 @@ class _slice:  # noqa: N801
         if stop is None or stop >= 0:
             return stop
 
-        stop += len(sized)
-        if stop >= 0:
-            return stop
-
-        return 0 if self.step > 0 else None
+        return _positivestop(stop, len(sized), self.step)
 
     def length(self, sized: Sized) -> int:
         origin = self

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -209,12 +209,13 @@ class _slice:  # noqa: N801
             size = self.length(sized)
             start = max(0, start + size)
 
+        start = self._resolve_start(start, step, sized)
+
         if stop is not None and stop < 0:
             stop += self.length(sized)
             if stop < 0:
                 stop = 0 if step > 0 else None
 
-        start = self._resolve_start(start, step, sized)
         stop = self._resolve_stop(stop, step, sized)
         step *= self.step
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -99,9 +99,6 @@ class _slice:  # noqa: N801
     def apply(self, iterable: Iterable[_T_co], sized: Sized) -> Iterator[_T_co]:
         return islice(iterable, *self.astuple())
 
-    def _positivestart(self, sized: Sized) -> Optional[int]:
-        return self.start
-
     def _positivestop(self, sized: Sized) -> Optional[int]:
         return self.stop
 
@@ -219,7 +216,7 @@ class _slice:  # noqa: N801
             return self.resolve(start, sized, strict=False)
 
         if step > 0:
-            return self._positivestart(sized)
+            return self.start
 
         stop = self._positivestop(sized)
 
@@ -240,7 +237,7 @@ class _slice:  # noqa: N801
         if step > 0:
             return self._positivestop(sized)
 
-        start = self._positivestart(sized)
+        start = self.start
 
         if start is None:
             return None

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -204,12 +204,11 @@ class _slice:  # noqa: N801
 
     def resolve_slice(self, slice: _slice, sized: Sized) -> _slice:
         start = slice.start
+        stop = slice.stop
 
         if start is not None and start < 0:
             size = self.length(sized)
             start = max(0, start + size)
-
-        stop = slice.stop
 
         if stop is not None and stop < 0:
             stop += self.length(sized)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -99,9 +99,6 @@ class _slice:  # noqa: N801
     def apply(self, iterable: Iterable[_T_co], sized: Sized) -> Iterator[_T_co]:
         return islice(iterable, *self.astuple())
 
-    def _positivestop(self, sized: Sized) -> Optional[int]:
-        return self.stop
-
     def length(self, sized: Sized) -> int:
         origin = self
 
@@ -218,7 +215,7 @@ class _slice:  # noqa: N801
         if step > 0:
             return self.start
 
-        stop = self._positivestop(sized)
+        stop = self.stop
 
         if stop is None:
             return None
@@ -235,7 +232,7 @@ class _slice:  # noqa: N801
             return self.resolve(stop, sized, strict=False)
 
         if step > 0:
-            return self._positivestop(sized)
+            return self.stop
 
         start = self.start
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -352,7 +352,12 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
     def _getslice(self, indices: slice) -> lazysequence[_T_co]:  # noqa: C901
         slice = _slice.fromslice(indices)
 
-        start = slice.positivestart(self)
+        start: Optional[int]
+        if slice.start is not None and slice.start < 0:
+            start = max(0, slice.start + len(self))
+        else:
+            start = slice.start
+
         stop = slice.positivestop(self)
 
         slice = _slice(start, stop, slice.step)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -203,12 +203,11 @@ class _slice:  # noqa: N801
         return index
 
     def resolve_slice(self, slice: _slice, sized: Sized) -> _slice:
-        start: Optional[int]
+        start = slice.start
+
         if slice.start is not None and slice.start < 0:
             size = self.length(sized)
             start = max(0, slice.start + size)
-        else:
-            start = slice.start
 
         stop = slice.stop
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -82,9 +82,9 @@ class _slice:  # noqa: N801
         return self.start, self.stop, self.step
 
     def apply(self, iterable: Iterable[_T_co], sized: Sized) -> Iterator[_T_co]:
-        return islice(iterable, *self.positive(sized).astuple())
+        return islice(iterable, *self._positive(sized).astuple())
 
-    def positive(self, sized: Sized) -> _slice:
+    def _positive(self, sized: Sized) -> _slice:
         start = self._positivestart(sized)
         stop = self._positivestop(sized)
 
@@ -113,7 +113,7 @@ class _slice:  # noqa: N801
         if origin.step < 0:
             origin = origin.reverse(sized)
 
-        start, stop, step = origin.positive(sized).astuple()
+        start, stop, step = origin._positive(sized).astuple()
         size = len(sized)
 
         if stop is not None:
@@ -132,7 +132,7 @@ class _slice:  # noqa: N801
     def reverse(self, sized: Sized) -> _slice:
         assert self.step < 0  # noqa: S101
 
-        start, stop, step = self.positive(sized).astuple()
+        start, stop, step = self._positive(sized).astuple()
         size = len(sized)
         step = -step
 
@@ -162,7 +162,7 @@ class _slice:  # noqa: N801
         """Resolve index on a forward slice, where start <= stop and step > 0."""
         assert self.step > 0  # noqa: S101
 
-        start, stop, step = self.positive(sized).astuple()
+        start, stop, step = self._positive(sized).astuple()
 
         if start is None:
             start = 0
@@ -185,7 +185,7 @@ class _slice:  # noqa: N801
         assert self.step < 0  # noqa: S101
 
         size = len(sized)
-        start, stop, step = self.positive(sized).astuple()
+        start, stop, step = self._positive(sized).astuple()
 
         if start is None:
             start = size - 1

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -203,9 +203,7 @@ class _slice:  # noqa: N801
         return index
 
     def resolve_slice(self, slice: _slice, sized: Sized) -> _slice:
-        start = slice.start
-        stop = slice.stop
-        step = slice.step
+        start, stop, step = slice.astuple()
 
         if start is not None and start < 0:
             size = self.length(sized)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -351,7 +351,11 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
     def _getslice(self, indices: slice) -> lazysequence[_T_co]:  # noqa: C901
         slice = _slice.fromslice(indices)
-        slice = slice.positive(self)
+
+        start = slice.positivestart(self)
+        stop = slice.positivestop(self)
+
+        slice = _slice(start, stop, slice.step)
         slice = self._slice.resolve_slice(slice, self._total)
 
         return lazysequence(self._iter, _cache=self._cache, _indices=slice.asslice())

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -205,9 +205,9 @@ class _slice:  # noqa: N801
     def resolve_slice(self, slice: _slice, sized: Sized) -> _slice:
         start = slice.start
 
-        if slice.start is not None and slice.start < 0:
+        if start is not None and start < 0:
             size = self.length(sized)
-            start = max(0, slice.start + size)
+            start = max(0, start + size)
 
         stop = slice.stop
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -239,8 +239,6 @@ class _slice:  # noqa: N801
             if stop < 0:
                 stop = 0 if step > 0 else None
 
-        assert stop is None or stop >= 0  # noqa: S101
-
         if stop is not None:
             return self.resolve(stop, sized, strict=False)
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -214,7 +214,7 @@ class _slice:  # noqa: N801
         if stop is not None and stop < 0:
             stop += self.length(sized)
             if stop < 0:
-                stop = 0 if slice.step > 0 else None
+                stop = 0 if step > 0 else None
 
         start = self._resolve_start(start, step, sized)
         stop = self._resolve_stop(stop, step, sized)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -362,9 +362,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
         if stop is not None and stop < 0:
             stop += len(self)
-            if stop >= 0:
-                pass
-            else:
+            if stop < 0:
                 stop = 0 if slice.step > 0 else None
 
         slice = _slice(start, stop, slice.step)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -217,9 +217,7 @@ class _slice:  # noqa: N801
             if stop < 0:
                 stop = 0 if slice.step > 0 else None
 
-        slice = _slice(start, stop, slice.step)
-
-        start, stop, step = slice.astuple()
+        start, stop, step = _slice(start, stop, slice.step).astuple()
 
         start = self._resolve_start(start, step, sized)
         stop = self._resolve_stop(stop, step, sized)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -215,12 +215,10 @@ class _slice:  # noqa: N801
         if step > 0:
             return self.start
 
-        stop = self.stop
-
-        if stop is None:
+        if self.stop is None:
             return None
 
-        return stop + 1 if self.step < 0 else stop - 1
+        return self.stop + 1 if self.step < 0 else self.stop - 1
 
     def _resolve_stop(
         self, stop: Optional[int], step: int, sized: Sized

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -217,7 +217,7 @@ class _slice:  # noqa: N801
             if stop < 0:
                 stop = 0 if slice.step > 0 else None
 
-        start, stop, step = _slice(start, stop, slice.step).astuple()
+        step = slice.step
 
         start = self._resolve_start(start, step, sized)
         stop = self._resolve_stop(stop, step, sized)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -354,7 +354,8 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
         start: Optional[int]
         if slice.start is not None and slice.start < 0:
-            start = max(0, slice.start + len(self))
+            size = len(self)
+            start = max(0, slice.start + size)
         else:
             start = slice.start
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -205,6 +205,7 @@ class _slice:  # noqa: N801
     def resolve_slice(self, slice: _slice, sized: Sized) -> _slice:
         start = slice.start
         stop = slice.stop
+        step = slice.step
 
         if start is not None and start < 0:
             size = self.length(sized)
@@ -214,8 +215,6 @@ class _slice:  # noqa: N801
             stop += self.length(sized)
             if stop < 0:
                 stop = 0 if slice.step > 0 else None
-
-        step = slice.step
 
         start = self._resolve_start(start, step, sized)
         stop = self._resolve_stop(stop, step, sized)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -218,10 +218,8 @@ class _slice:  # noqa: N801
                 stop = 0 if slice.step > 0 else None
 
         slice = _slice(start, stop, slice.step)
-        return self.resolve_slice(slice, sized)
 
-    def resolve_slice(self, aslice: _slice, sized: Sized) -> _slice:
-        start, stop, step = aslice.astuple()
+        start, stop, step = slice.astuple()
 
         start = self._resolve_start(start, step, sized)
         stop = self._resolve_stop(stop, step, sized)


### PR DESCRIPTION
- _getslice: extract variable
- _getslice: inline function `positive`
- _getslice: inline function `positivestart`
- _getslice: inline function `positivestop`
- _getslice: simplify conditional logic
- _getslice: simplify conditional logic
- _getslice: extract variable `size`
- _getslice: inline function `__len__`
- _getslice: inline function `__len__`
- _slice.resolve_slice2: extract function from `_getslice`
- _slice.resolve_slice: inline function
- _slice.resolve_slice: rename function from `resolve_slice2`
- _slice.resolve_slice: inline variable `slice`
- _slice.resolve_slice: remove redundant copy of `start` and `stop`
- _slice.resolve_slice: slide statement
- _slice.resolve_slice: replace query with temp
- _slice.resolve_slice: slide statement
- _slice.resolve_slice: slide statement
- _slice.resolve_slice: replace query with temp
- _slice.resolve_slice: replace inline code with function call to `astuple`
- _slice.resolve_slice: slide statement
- _slice.resolve_start2: extract function from `resolve_slice`
- _slice._resolve_start: inline function
- _slice._resolve_start: rename function from `_resolve_start2`
- _slice.resolve_slice: move statements into function `_resolve_stop`
- _slice._resolve_start: remove assertion
- _slice._resolve_stop: remove assertion
- _slice._resolve_start: slide statement
- _slice._positivestart: rename function
- _slice._positivestop: rename function
- _slice._positive: rename function
- _positivestart: extract function from `_slice._positivestart`
- _slice._resolve_start: replace inline code with call to `_positivestart`
- _positivestop: extract function from `_slice._positivestop`
- _slice._resolve_stop: replace inline code with call to `_positivestop`
