### PR TITLE
:recycle: Use `_slice` type for the hidden `__init__` parameter

### DIFF
--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -257,7 +257,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         *,
         storage: Callable[[], MutableSequence[_T_co]] = deque,
         _cache: Optional[MutableSequence[_T_co]] = None,
-        _indices: _slice = _defaultslice,
+        _slice: _slice = _defaultslice,
     ) -> None:
         """Initialize."""
         parent = self
@@ -269,7 +269,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
         self._iter = iter(iterable)
         self._cache = storage() if _cache is None else _cache
-        self._slice = _indices
+        self._slice = _slice
         self._total = _Total()
 
     def _consume(self) -> Iterator[_T_co]:
@@ -343,7 +343,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         slice = _slice.fromslice(indices)
         slice = self._slice.resolve_slice(slice, self._total)
 
-        return lazysequence(self._iter, _cache=self._cache, _indices=slice)
+        return lazysequence(self._iter, _cache=self._cache, _slice=slice)
 
     @overload
     def __getitem__(self, index: int) -> _T_co:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -90,9 +90,6 @@ class _slice:  # noqa: N801
         object.__setattr__(self, "stop", stop)
         object.__setattr__(self, "step", step)
 
-    def asslice(self) -> slice:
-        return slice(*self.astuple())
-
     def astuple(self) -> Tuple[Optional[int], Optional[int], int]:
         return self.start, self.stop, self.step
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -73,10 +73,6 @@ class _slice:  # noqa: N801
     stop: Optional[int]
     step: int
 
-    @classmethod
-    def fromslice(cls, aslice: slice) -> _slice:
-        return cls(aslice.start, aslice.stop, aslice.step)
-
     def __init__(
         self, start: Optional[int], stop: Optional[int], step: Optional[int]
     ) -> None:
@@ -337,7 +333,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             raise IndexError("lazysequence index out of range") from None
 
     def _getslice(self, indices: slice) -> lazysequence[_T_co]:  # noqa: C901
-        slice = _slice.fromslice(indices)
+        slice = _slice(indices.start, indices.stop, indices.step)
         slice = self._slice.resolve_slice(slice, self._total)
 
         return lazysequence(self._iter, _cache=self._cache, _slice=slice)

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -238,7 +238,7 @@ class _slice:  # noqa: N801
         return self.start + 1 if self.step < 0 else self.start - 1
 
 
-_defaultslice = slice(None)
+_defaultslice = _slice(None, None, None)
 
 
 class lazysequence(Sequence[_T_co]):  # noqa: N801
@@ -257,7 +257,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         *,
         storage: Callable[[], MutableSequence[_T_co]] = deque,
         _cache: Optional[MutableSequence[_T_co]] = None,
-        _indices: slice = _defaultslice,
+        _indices: _slice = _defaultslice,
     ) -> None:
         """Initialize."""
         parent = self
@@ -269,7 +269,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
         self._iter = iter(iterable)
         self._cache = storage() if _cache is None else _cache
-        self._slice = _slice.fromslice(_indices)
+        self._slice = _indices
         self._total = _Total()
 
     def _consume(self) -> Iterator[_T_co]:
@@ -343,7 +343,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         slice = _slice.fromslice(indices)
         slice = self._slice.resolve_slice(slice, self._total)
 
-        return lazysequence(self._iter, _cache=self._cache, _indices=slice.asslice())
+        return lazysequence(self._iter, _cache=self._cache, _indices=slice)
 
     @overload
     def __getitem__(self, index: int) -> _T_co:


### PR DESCRIPTION
- `__init__`: change parameter type from `slice` to `_slice`
- `__init__`: rename parameter `_indices` to `_slice`
