### PR TITLE
:bug: Allow interleaved iteration over sequences with shared data

### DIFF
--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -348,11 +348,11 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         """Iterate over the items in the sequence."""
 
         def generate() -> Iterator[_T_co]:
+            yield from self._cache
+
+            offset = len(self._cache) + 1
+
             try:
-                yield from self._cache
-
-                offset = len(self._cache) + 1
-
                 yield next(self._consume())
 
                 for index in count(offset):

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -348,6 +348,12 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         """Iterate over the items in the sequence."""
 
         def generate() -> Iterator[_T_co]:
+            """Essentially the same as ``chain(self._cache, self._consume())``.
+
+            Other instances may be consuming items from the iterator though, so
+            after each ``next()`` on the iterator, try the cache again. Also,
+            yield from the cache first, as it's much faster than the loop below.
+            """
             yield from self._cache
 
             offset = len(self._cache) + 1

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -352,14 +352,16 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
             offset = len(self._cache) + 1
 
+            consumer = self._consume()
+
             try:
-                yield next(self._consume())
+                yield next(consumer)
 
                 for index in count(offset):
                     try:
                         yield self._cache[index]
                     except IndexError:
-                        yield next(self._consume())
+                        yield next(consumer)
             except StopIteration:
                 pass
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -335,9 +335,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         """Iterate over the items in the sequence."""
         slice = self._slice
 
-        if slice.step > 0:
-            iterator = chain(self._cache, iterator)
-        else:
+        if slice.step < 0:
             slice = slice.reverse(self._total)
 
             self._fill()
@@ -347,7 +345,8 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
     def __iter__(self) -> Iterator[_T_co]:
         """Iterate over the items in the sequence."""
-        return self._iterate(self._consume())
+        iterator = chain(self._cache, self._consume())
+        return self._iterate(iterator)
 
     def release(self) -> Iterator[_T_co]:
         """Iterate over the sequence without caching additional items.
@@ -358,7 +357,8 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         Yields:
             The items in the sequence.
         """  # noqa: DAR201, DAR302
-        return self._iterate(self._iter)
+        iterator = chain(self._cache, self._iter)
+        return self._iterate(iterator)
 
     def __bool__(self) -> bool:
         """Return True if there are any items in the sequence."""

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -349,7 +349,13 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
 
         def generate() -> Iterator[_T_co]:
             try:
-                for index in count():
+                yield from self._cache
+
+                offset = len(self._cache) + 1
+
+                yield next(self._consume())
+
+                for index in count(offset):
                     try:
                         yield self._cache[index]
                     except IndexError:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -348,18 +348,14 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
         """Iterate over the items in the sequence."""
 
         def generate() -> Iterator[_T_co]:
-            for index in count():
-                try:
-                    yield self._cache[index]
-                except IndexError:
-                    pass
-                else:
-                    continue
-
-                try:
-                    yield next(self._consume())
-                except StopIteration:
-                    break
+            try:
+                for index in count():
+                    try:
+                        yield self._cache[index]
+                    except IndexError:
+                        yield next(self._consume())
+            except StopIteration:
+                pass
 
         return self._iterate(generate())
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -357,7 +357,6 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             yield from self._cache
 
             offset = len(self._cache) + 1
-
             consumer = self._consume()
 
             try:

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -357,9 +357,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
                     continue
 
                 try:
-                    item = next(self._iter)
-                    self._cache.append(item)
-                    yield item
+                    yield next(self._consume())
                 except StopIteration:
                     break
 

--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -362,7 +362,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
             try:
                 yield next(consumer)
 
-                for index in count(offset):
+                for index in count(offset):  # pragma: no branch
                     try:
                         yield self._cache[index]
                     except IndexError:

--- a/tests/test_lazysequence.py
+++ b/tests/test_lazysequence.py
@@ -1,6 +1,7 @@
 """Unit tests for lazysequence."""
 from typing import List
 from typing import Optional
+from typing import Sequence
 from typing import Tuple
 
 import pytest
@@ -460,3 +461,13 @@ def test_slice_of_slice(
     """It contains the same items as a list."""
     lazy, strict = createslices(size, start, stop, step)
     assert strict[indices] == list(lazy[indices])
+
+
+def test_interleaved_iteration() -> None:
+    """It allows simultaneous iteration over multiple related instances."""
+    lazy, strict = lazysequence(range(5)), list(range(5))
+
+    def transform(s: Sequence[int]) -> List[Tuple[int, int]]:
+        return list(zip(s, s[1:]))
+
+    assert transform(strict) == transform(lazy)


### PR DESCRIPTION
- :white_check_mark: Add failing test for interleaved iteration
- :recycle: _iterate: move statement to callers
- :bug: Allow interleaved iteration over sequences with shared data
- :recycle: replace inline code with function call to `_consume`
- :recycle: simplify control flow
- :racehorse: try `yield from cache` first
- :recycle: slide statement
- :racehorse: reuse `_consume` generator
- :bulb: Add docstring to generator
- :art: save a newline
