### PR TITLE
:bug: Fix crash when using multiple iterators over the same sequence

### DIFF
--- a/src/lazysequence/__init__.py
+++ b/src/lazysequence/__init__.py
@@ -32,7 +32,6 @@ record 9
 """
 from __future__ import annotations
 
-from collections import deque
 from dataclasses import dataclass
 from itertools import chain
 from itertools import count
@@ -313,7 +312,7 @@ class lazysequence(Sequence[_T_co]):  # noqa: N801
                 return len(parent._cache)
 
         self._iter = iter(iterable)
-        self._cache = deque() if _cache is None else _cache
+        self._cache = [] if _cache is None else _cache
         self._slice = _slice
         self._total = _Total()
 

--- a/tests/test_lazysequence.py
+++ b/tests/test_lazysequence.py
@@ -464,3 +464,13 @@ def test_interleaved_iteration() -> None:
         return list(zip(s, s[1:]))
 
     assert transform(strict) == transform(lazy)
+
+
+def test_cache_mutation_during_iteration() -> None:
+    """It allows the cache to be mutated during iteration."""
+    s = lazysequence(range(5))
+    a, b = iter(s), iter(s)
+    next(a)
+    next(b)
+    next(a)
+    next(b)


### PR DESCRIPTION
- :white_check_mark: Add failing test for cache mutation during iteration
- :bug: Use `list` as cache type to fix crash with multiple iterators
